### PR TITLE
Mongo::InvalidNSName - database names cannot contain the character '.':


### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,9 @@
 $: << File.dirname(__FILE__) + "/lib"
-require "rack/oauth2/server"
+require 'rubygems'
+require 'sinatra'
+require "rack/oauth2/sinatra"
+require "rack/oauth2/server/admin"
+
 Rack::OAuth2::Server.database = Mongo::Connection.new["test"]
 
 class Authorize < Sinatra::Base

--- a/lib/rack/oauth2/models/access_grant.rb
+++ b/lib/rack/oauth2/models/access_grant.rb
@@ -25,7 +25,7 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.access_grants"]
+            Server.database["oauth2-access_grants"]
           end
         end
 

--- a/lib/rack/oauth2/models/access_token.rb
+++ b/lib/rack/oauth2/models/access_token.rb
@@ -83,7 +83,7 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.access_tokens"]
+            Server.database["oauth2-access_tokens"]
           end
         end
 

--- a/lib/rack/oauth2/models/auth_request.rb
+++ b/lib/rack/oauth2/models/auth_request.rb
@@ -28,7 +28,7 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.auth_requests"]
+            Server.database["oauth2-auth_requests"]
           end
         end
 

--- a/lib/rack/oauth2/models/client.rb
+++ b/lib/rack/oauth2/models/client.rb
@@ -66,9 +66,10 @@ module Rack
           end
 
           def collection
-            Server.database["oauth2.clients"]
+            Server.database["oauth2-clients"]
           end
-        end
+        end 
+        # end of class methods
 
         # Client identifier.
         attr_reader :_id

--- a/rack-oauth2-server.gemspec
+++ b/rack-oauth2-server.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.version        = IO.read("VERSION")
   spec.author         = "Assaf Arkin"
   spec.email          = "assaf@labnotes.org"
-  spec.homepage       = "http://github.com/assaf/#{spec.name}"
+  spec.homepage       = "https://github.com/flowtown/rack-oauth2-server/#{spec.name}"
   spec.summary        = "OAuth 2.0 Authorization Server as a Rack module"
   spec.description    = "Because you don't allow strangers into your app, and OAuth 2.0 is the new awesome."
   spec.post_install_message = "To get started, run the command oauth2-server"


### PR DESCRIPTION
I was getting the error in the title, so changed the database names to use - instead of .

Here is the relevant section from the mongo driver:

```
# File 'lib/mongo/util/support.rb', line 48

def validate_db_name(db_name)
  unless [String, Symbol].include?(db_name.class)
    raise TypeError, "db_name must be a string or symbol"
  end

  [" ", ".", "$", "/", "\\"].each do |invalid_char|
    if db_name.include? invalid_char
      raise Mongo::InvalidNSName, "database names cannot contain the character '#{invalid_char}'"
    end
  end
  raise Mongo::InvalidNSName, "database name cannot be the empty string" if db_name.empty?
  db_name
end
```
