### PR TITLE
Content type header on redirects

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -287,7 +287,7 @@ module Rack
             auth_request = AuthRequest.create(client, requested_scope, redirect_uri.to_s, response_type, state)
             uri = URI.parse(request.url)
             uri.query = "authorization=#{auth_request.id.to_s}"
-            return [303, { "Content-Type"=>"text/plain", "Location"=>uri.to_s }, ["You are being redirected"]]
+            return redirect_to(uri, 303)
           end
         rescue OAuthError=>error
           logger.error "RO2S: Authorization request error #{error.code}: #{error.message}" if logger
@@ -409,9 +409,10 @@ module Rack
         raise InvalidClientError
       end
 
-      # Rack redirect response. The argument is typically a URI object.
-      def redirect_to(uri)
-        return [302, { "Content-Type"=>"text/plain", "Location"=>uri.to_s }, ["You are being redirected"]]
+      # Rack redirect response.
+      # The argument is typically a URI object, and the status should be a 302 or 303.
+      def redirect_to(uri, status = 302)
+        return [status, { "Content-Type"=>"text/plain", "Location"=>uri.to_s }, ["You are being redirected"]]
       end
 
       def bad_request(message)

--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -287,7 +287,7 @@ module Rack
             auth_request = AuthRequest.create(client, requested_scope, redirect_uri.to_s, response_type, state)
             uri = URI.parse(request.url)
             uri.query = "authorization=#{auth_request.id.to_s}"
-            return [303, { "Location"=>uri.to_s }, ["You are being redirected"]]
+            return [303, { "Content-Type"=>"text/plain", "Location"=>uri.to_s }, ["You are being redirected"]]
           end
         rescue OAuthError=>error
           logger.error "RO2S: Authorization request error #{error.code}: #{error.message}" if logger
@@ -411,7 +411,7 @@ module Rack
 
       # Rack redirect response. The argument is typically a URI object.
       def redirect_to(uri)
-        return [302, { "Location"=>uri.to_s }, ["You are being redirected"]]
+        return [302, { "Content-Type"=>"text/plain", "Location"=>uri.to_s }, ["You are being redirected"]]
       end
 
       def bad_request(message)


### PR DESCRIPTION
The redirects in Rack::OAuth2::Server do not currently set a Content-Type header, which causes failures if Rack::Lint is used. These commits set a "text/plain" content type and consolidate to a single redirect method, which should ensure consistent application of headers. I contemplated adding tests to authorization_test.rb, but I wasn't sure it made sense to be explicit about the content type of the responses.
