### PR TITLE
Add support for configurable expiry period for all auth tokens

### DIFF
--- a/lib/rack/oauth2/models/access_token.rb
+++ b/lib/rack/oauth2/models/access_token.rb
@@ -89,7 +89,7 @@ module Rack
           end
           
           def set_token_expiry token
-            token[:expires_at] = (Time.now + (Server.options.expire_days * 24 * 60 * 60)).to_i if Server.options.tokens_expire
+            token[:expires_at] = (Time.now + (Server.options.expire_days * 24 * 60 * 60)).to_i if Server.options.expire_days > 0
           end
         end
 

--- a/lib/rack/oauth2/models/access_token.rb
+++ b/lib/rack/oauth2/models/access_token.rb
@@ -14,6 +14,7 @@ module Rack
             scope = Utils.normalize_scope(scope) & client.scope # Only allowed scope
             token = { :_id=>Server.secure_random, :scope=>scope, :client_id=>client.id,
                       :created_at=>Time.now.to_i, :expires_at=>nil, :revoked=>nil }
+            set_token_expiry token
             collection.insert token
             Client.collection.update({ :_id=>client.id }, { :$inc=>{ :tokens_granted=>1 } })
             Server.new_instance self, token
@@ -32,6 +33,7 @@ module Rack
               token = { :_id=>Server.secure_random, :identity=>identity, :scope=>scope,
                         :client_id=>client.id, :created_at=>Time.now.to_i,
                         :expires_at=>nil, :revoked=>nil }
+              set_token_expiry token
               collection.insert token
               Client.collection.update({ :_id=>client.id }, { :$inc=>{ :tokens_granted=>1 } })
             end
@@ -84,6 +86,10 @@ module Rack
 
           def collection
             Server.database["oauth2.access_tokens"]
+          end
+          
+          def set_token_expiry token
+            token[:expires_at] = (Time.now + (Server.options.expire_days * 24 * 60 * 60)).to_i if Server.options.tokens_expire
           end
         end
 

--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -136,6 +136,7 @@ module Rack
       #   query/form parameters.
       # - :realm -- Authorization realm that will show up in 401 responses.
       #   Defaults to use the request host name.
+      # - :expire_days -- Number of days an auth token will live. Defaults to no expiry.
       # - :logger -- The logger to use. Under Rails, defaults to use the Rails
       #   logger.  Will use Rack::Logger if available.
       #
@@ -148,7 +149,7 @@ module Rack
       #     user if user && user.authenticated?(password)
       #   end
       Options = Struct.new(:access_token_path, :authenticator, :authorization_types,
-        :authorize_path, :database, :host, :param_authentication, :path, :realm, :tokens_expire, 
+        :authorize_path, :database, :host, :param_authentication, :path, :realm, 
         :expire_days,:logger)
 
       # Global options. This is what we set during configuration (e.g. Rails'
@@ -167,8 +168,7 @@ module Rack
         @options.authorize_path ||= "/oauth/authorize"
         @options.authorization_types ||=  %w{code token}
         @options.param_authentication ||= false
-        @options.tokens_expire ||= false
-        @options.expire_days ||= 365
+        @options.expire_days ||= 0
       end
 
       # Options specific for this handle. @see Options

--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -148,7 +148,8 @@ module Rack
       #     user if user && user.authenticated?(password)
       #   end
       Options = Struct.new(:access_token_path, :authenticator, :authorization_types,
-        :authorize_path, :database, :host, :param_authentication, :path, :realm, :logger)
+        :authorize_path, :database, :host, :param_authentication, :path, :realm, :tokens_expire, 
+        :expire_days,:logger)
 
       # Global options. This is what we set during configuration (e.g. Rails'
       # config/application), and options all handlers inherit by default.
@@ -166,6 +167,8 @@ module Rack
         @options.authorize_path ||= "/oauth/authorize"
         @options.authorization_types ||=  %w{code token}
         @options.param_authentication ||= false
+        @options.tokens_expire ||= false
+        @options.expire_days ||= 365
       end
 
       # Options specific for this handle. @see Options

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -25,6 +25,8 @@ Rack::OAuth2::Server::Admin.configure do |config|
   config.set :logging, true
   config.set :raise_errors, true
   config.set :dump_errors, true
+  config.oauth.tokens_expire = true
+  config.oauth.expire_days = 1
   config.oauth.logger = $logger
 end
 

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -25,7 +25,6 @@ Rack::OAuth2::Server::Admin.configure do |config|
   config.set :logging, true
   config.set :raise_errors, true
   config.set :dump_errors, true
-  config.oauth.tokens_expire = true
   config.oauth.expire_days = 1
   config.oauth.logger = $logger
 end


### PR DESCRIPTION
Chose not to implement the refresh token as its marked optional in the spec.
