### PR TITLE
Rack::Lint::LintError: No Content-Type header found

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -430,7 +430,7 @@ module Rack
       def unauthorized(request, error = nil)
         challenge = 'OAuth realm="%s"' % (options.realm || request.host)
         challenge << ', error="%s", error_description="%s"' % [error.code, error.message] if error
-        return [401, { "WWW-Authenticate"=>challenge }, [error && error.message || ""]]
+        return [401, { "Content-Type"=>"text/plain", "WWW-Authenticate"=>challenge }, [error && error.message || ""]]
       end
 
       # Wraps Rack::Request to expose Basic and OAuth authentication


### PR DESCRIPTION
Instead of having a "401 Unauthorized" response when oauth is not authenticated (oauth.no_access), it's being raised a "500 Internal Server Error" with "Rack::Lint::LintError: No Content-Type header found" exception.

I had this problem using Sinatra in development environment and running a Rack server (rackup). It happens because rackup servers automatically add Rack::Lint in development mode.

To ensure Rack protocol is being followed, there must be a Content-type header in all responses, except when the status is 1xx, 204 or 304.

Following this idea, rack-oauth2-server needs to add a Content-type header when returns an unauthorized response:

return [401, { "Content-Type"=>"text/plain", "WWW-Authenticate"=>challenge }, [error && error.message || ""]]
